### PR TITLE
Fix Alembic export exporting full scene

### DIFF
--- a/client/ayon_cinema4d/plugins/publish/extract_alembic.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_alembic.py
@@ -46,7 +46,9 @@ class ExtractAlembic(publish.Extractor):
                 frame_step=step,
                 selection=True,
                 global_matrix=bake_to_worldspace,
-                doc=doc
+                doc=doc,
+                # Log the applied options to the publish logs
+                verbose=True
             )
 
         representation = {


### PR DESCRIPTION
## Changelog Description

Add workaround for bug where export options are applied in C4D on first time setting it - so we set it twice.

## Additional info

Fixes #6, where full scene is exported instead of selection

## Testing notes:

1. Launch C4D
2. Publish pointcache with 1 member, but two objects in the scene
3. Only the 1 member of the pointcache should be included in the export.
