### PR TITLE
Implement Redshift Proxy product and loader + add VDB loaders

### DIFF
--- a/client/ayon_cinema4d/api/lib.py
+++ b/client/ayon_cinema4d/api/lib.py
@@ -366,6 +366,11 @@ def get_objects_from_container(container, existing_only=True):
     doc: c4d.documents.BaseDocument = container.GetMain()
     assert isinstance(doc, c4d.documents.BaseDocument)
     in_exclude_data = container[c4d.SELECTIONOBJECT_LIST]
+
+    # If the container is not a selection object list yield no child objects
+    if not in_exclude_data:
+        return
+
     object_count = in_exclude_data.GetObjectCount()
     for i in range(object_count):
         obj = in_exclude_data.ObjectFromIndex(doc, i)

--- a/client/ayon_cinema4d/api/pipeline.py
+++ b/client/ayon_cinema4d/api/pipeline.py
@@ -52,7 +52,8 @@ class Cinema4DHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         register_loader_plugin_path(LOAD_PATH)
         register_creator_plugin_path(CREATE_PATH)
-        register_inventory_action_path(INVENTORY_PATH)
+        # TODO: Register only when any inventory actions are created
+        # register_inventory_action_path(INVENTORY_PATH)
         self.log.info(PUBLISH_PATH)
 
     def open_workfile(self, filepath):

--- a/client/ayon_cinema4d/api/pipeline.py
+++ b/client/ayon_cinema4d/api/pipeline.py
@@ -8,7 +8,6 @@ import pyblish.api
 from ayon_core.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
 from ayon_core.pipeline import (
     register_loader_plugin_path,
-    register_inventory_action_path,
     register_creator_plugin_path,
     AYON_CONTAINER_ID,
 )

--- a/client/ayon_cinema4d/api/pipeline.py
+++ b/client/ayon_cinema4d/api/pipeline.py
@@ -140,7 +140,7 @@ def iter_containers(doc=None):
     """Yield all objects in the active document that have 'id' attribute set
     matching an AYON container ID"""
     doc = doc or c4d.documents.GetActiveDocument()
-    containers = lib.get_objects_by_type("Selection", doc.GetFirstObject(), [])
+    containers = lib.iter_objects(doc.GetFirstObject())
     for container in containers:
         if lib.get_object_user_data_by_name(container, "id") != AYON_CONTAINER_ID:  # noqa
             continue
@@ -220,16 +220,14 @@ def containerise(name,
         doc = lib.active_document()
         doc.InsertObject(container)
 
-        data = {
-            "schema": "ayon:container-3.0",
-            "id": AYON_CONTAINER_ID,
-            "name": name,
-            "namespace": namespace,
-            "loader": str(loader),
-            "representation": str(context["representation"]["id"]),
-        }
+        imprint_container(
+            container,
+            name,
+            namespace,
+            context,
+            loader=None
+        )
 
-        lib.imprint(container, data, group="AYON")
         # Add the container to the AYON_CONTAINERS layer
         avalon_layer = get_containers_layer(doc=doc)
         container.SetLayerObject(avalon_layer)
@@ -238,3 +236,31 @@ def containerise(name,
         c4d.EventAdd()
 
     return container
+
+
+def imprint_container(
+    container,
+    name,
+    namespace,
+    context,
+    loader=None
+):
+    """Imprints an object with container metadata and hides it from the user
+    by adding it into a hidden layer.
+    Arguments:
+        container (c4d.BaseObject): The object to imprint.
+        name (str): Name of resulting assembly
+        namespace (str): Namespace under which to host container
+        context (dict): Asset information
+        loader (str, optional): Name of loader used to produce this container.
+    """
+    data = {
+        "schema": "ayon:container-3.0",
+        "id": AYON_CONTAINER_ID,
+        "name": name,
+        "namespace": namespace,
+        "loader": str(loader),
+        "representation": str(context["representation"]["id"]),
+    }
+
+    lib.imprint(container, data, group="AYON")

--- a/client/ayon_cinema4d/plugins/create/create_redshift_proxy.py
+++ b/client/ayon_cinema4d/plugins/create/create_redshift_proxy.py
@@ -1,0 +1,18 @@
+from ayon_cinema4d.api import (
+    lib,
+    plugin
+)
+
+
+class CreateRedshiftProxy(plugin.Cinema4DCreator):
+    """Redshift Proxy"""
+
+    identifier = "io.ayon.creators.cinema4d.redshiftproxy"
+    label = "Redshift Proxy"
+    product_type = "redshiftproxy"
+    description = __doc__
+    icon = "cubes"
+
+    def get_instance_attr_defs(self):
+        defs = lib.collect_animation_defs(self.create_context)
+        return defs

--- a/client/ayon_cinema4d/plugins/load/load_alembic.py
+++ b/client/ayon_cinema4d/plugins/load/load_alembic.py
@@ -8,7 +8,7 @@ class AlembicLoader(plugin.Cinema4DLoader):
 
     color = "orange"
     product_types = {"*"}
-    icon = "file-video-o"
+    icon = "code-fork"
     label = "Load Alembic"
     order = -10
     representations = {"abc"}

--- a/client/ayon_cinema4d/plugins/load/load_redshiftproxy.py
+++ b/client/ayon_cinema4d/plugins/load/load_redshiftproxy.py
@@ -8,7 +8,7 @@ class RedshiftProxyLoader(plugin.Cinema4DSingleObjLoader):
 
     color = "orange"
     product_types = {"*"}
-    icon = "file-video-o"
+    icon = "code-fork"
     label = "Load Redshift Proxy"
     order = -10
     representations = {"rs"}

--- a/client/ayon_cinema4d/plugins/load/load_redshiftproxy.py
+++ b/client/ayon_cinema4d/plugins/load/load_redshiftproxy.py
@@ -1,0 +1,26 @@
+import c4d
+
+from ayon_cinema4d.api import plugin
+
+
+class RedshiftProxyLoader(plugin.Cinema4DSingleObjLoader):
+    """Load Redshift Proxy."""
+
+    color = "orange"
+    product_types = {"*"}
+    icon = "file-video-o"
+    label = "Load Redshift Proxy"
+    order = -10
+    representations = {"rs"}
+
+    # TODO: Automatically enable 'animation' on the redshift proxy with
+    #  the correct frame start / frame end and offsets so it plays at the
+    #  same frames as the source scene.
+
+    @property
+    def _node_type_id(self):
+        return 1038649  # Redshift Proxy ID
+
+    @property
+    def _filepath_attribute(self):
+        return c4d.REDSHIFT_PROXY_FILE, c4d.REDSHIFT_FILE_PATH

--- a/client/ayon_cinema4d/plugins/load/load_vdb_to_redshift.py
+++ b/client/ayon_cinema4d/plugins/load/load_vdb_to_redshift.py
@@ -1,0 +1,25 @@
+import c4d
+
+from ayon_cinema4d.api import plugin
+
+
+class LoadVDBToRedshift(plugin.Cinema4DSingleObjLoader):
+    """Load VDB to Redshift Volume."""
+
+    color = "orange"
+    product_types = {"*"}
+    icon = "file-video-o"
+    label = "Load VDB to Redshift"
+    order = -10
+    representations = {"vdb"}
+
+    # TODO: Automatically set Animation to "Frame" when loading a vdb sequence
+    #  and correctly set the start frame, end frame and offsets
+
+    @property
+    def _node_type_id(self) -> int:
+        return 1038655  # Redshift Volume ID
+
+    @property
+    def _filepath_attribute(self):
+        return c4d.REDSHIFT_VOLUME_FILE, c4d.REDSHIFT_FILE_PATH

--- a/client/ayon_cinema4d/plugins/load/load_vdb_to_redshift.py
+++ b/client/ayon_cinema4d/plugins/load/load_vdb_to_redshift.py
@@ -8,7 +8,7 @@ class LoadVDBToRedshift(plugin.Cinema4DSingleObjLoader):
 
     color = "orange"
     product_types = {"*"}
-    icon = "file-video-o"
+    icon = "cloud"
     label = "Load VDB to Redshift"
     order = -10
     representations = {"vdb"}

--- a/client/ayon_cinema4d/plugins/load/load_volume.py
+++ b/client/ayon_cinema4d/plugins/load/load_volume.py
@@ -1,0 +1,22 @@
+import c4d
+
+from ayon_cinema4d.api import plugin
+
+
+class LoadVolume(plugin.Cinema4DSingleObjLoader):
+    """Load VDB to Volume Loader."""
+
+    color = "orange"
+    product_types = {"*"}
+    icon = "file-video-o"
+    label = "Load VDB to Volume Loader"
+    order = -10
+    representations = {"vdb"}
+
+    @property
+    def _node_type_id(self) -> int:
+        return 1039866  # Volume Loader ID
+
+    @property
+    def _filepath_attribute(self):
+        return c4d.ID_VOLUMESEQUENCE_PATH

--- a/client/ayon_cinema4d/plugins/load/load_volume.py
+++ b/client/ayon_cinema4d/plugins/load/load_volume.py
@@ -8,7 +8,7 @@ class LoadVolume(plugin.Cinema4DSingleObjLoader):
 
     color = "orange"
     product_types = {"*"}
-    icon = "file-video-o"
+    icon = "cloud"
     label = "Load VDB to Volume Loader"
     order = -10
     representations = {"vdb"}

--- a/client/ayon_cinema4d/plugins/publish/extract_redshiftproxy.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_redshiftproxy.py
@@ -1,0 +1,81 @@
+import os
+import c4d
+
+from ayon_core.pipeline import publish
+from ayon_cinema4d.api import lib, exporters
+
+
+class ExtractRedshiftProxy(publish.Extractor):
+    """Extract a Redshift Proxy"""
+
+    label = "Redshift Proxy"
+    hosts = ["cinema4d"]
+    families = ["redshiftproxy"]
+
+    def process(self, instance):
+
+        doc: c4d.BaseDocument = instance.context.data["doc"]
+
+        # Collect the start and end including handles
+        start = instance.data["frameStartHandle"]
+        end = instance.data["frameEndHandle"]
+        step = instance.data.get("step", 1)
+
+        export_nodes = instance[:]
+        # Define extract output file path
+        dir_path = self.staging_dir(instance)
+
+        # Add the `_` suffix because Redshift Proxy export will add the
+        # frame numbers to the file names before the extension.
+        filename = "{0}_.rs".format(instance.name)
+        path = os.path.join(dir_path, filename)
+
+        # TODO: Set the document timeline to 'fit' the extra frame start and
+        #  frame end because redshift export fails if the frame range is
+        #  outside of the current document's timeline range.
+
+        # Perform alembic extraction
+        with lib.maintained_selection():
+            lib.set_selection(doc, export_nodes)
+
+            # Export selection to camera
+            exporters.extract_redshiftproxy(
+                path,
+                frame_start=start,
+                frame_end=end,
+                frame_step=step,
+                selection=True,
+                doc=doc,
+                # Log the applied options to the publish logs
+                verbose=True
+            )
+
+        # The Redshift exporter will add the frame numbers to the filepath
+        # before the extension. So we collect the resulting files.
+        frame_filepaths: "list[str]" = []
+        for frame in range(int(start), int(end) + 1):
+            head, tail = os.path.splitext(path)
+            frame_filepath = f"{head}{frame:04d}{tail}"
+            if not os.path.exists(frame_filepath):
+                raise publish.PublishError(
+                    "Expected exported Redshift Proxy frame not found: "
+                    f"{frame_filepath}")
+
+            frame_filepaths.append(frame_filepath)
+
+        # Define the collected filename with the frame numbers
+        frame_filenames = [os.path.basename(path) for path in frame_filepaths]
+        if len(frame_filepaths) == 1:
+            files = frame_filenames[0]
+        else:
+            files = frame_filenames
+
+        representation = {
+            "name": "rs",
+            "ext": "rs",
+            "files": files,
+            "stagingDir": dir_path,
+        }
+        instance.data.setdefault("representations", []).append(representation)
+
+        self.log.info(f"Extracted instance '{instance.name}' to: {path}")


### PR DESCRIPTION
## Changelog Description

Implement Redshift Proxy product and loader + add VDB loaders for Redshift Volume and Volume Loader

## Additional info

Implements the creation of Redshift Proxy instances to publish and load back in. You can now load and share proxies between Cinema4D and other AYON host integrations supporting the Redshift Proxy product type.

Additionally, this PR adds VDB (`vdbcache`) product type loaders to load and manage Redshift Volume or Volume Loader objects inside Cinema4D. Allowing you to easily load and manage VDBs publish from for example Houdini or Tray Publisher (and others).

Also fixes some cosmetics: improves icons on loaders + avoids a redundant warning about inventory actions path.

## Testing notes:

1. Publishing of Redshift Proxy product type should work
2. Loading, updating and removing of Redshift proxies should work
3. Loading, updating and removing VDB caches should work
