### PR TITLE
Do not clash plug-in name with the `ExtractReview` from `ayon-core`

### DIFF
--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -5,7 +5,7 @@ from ayon_core.pipeline import publish
 from ayon_cinema4d.api import exporters
 
 
-class ExtractReview(publish.Extractor):
+class Cinema4DExtractReview(publish.Extractor):
 
     label = "Render Review"
     hosts = ["cinema4d"]


### PR DESCRIPTION
## Changelog Description

Do not clash plug-in name with the `ExtractReview` from `ayon-core`

## Additional info

Ensure class name doesn't clash in pyblish.

## Testing notes:

1. Extract Review should work.
