### PR TITLE
Fix support for Cinema4D 2024+

### DIFF
--- a/client/ayon_cinema4d/startup/ayon_cinema4d.pyp
+++ b/client/ayon_cinema4d/startup/ayon_cinema4d.pyp
@@ -209,19 +209,25 @@ def install_menu():
     menu = c4d.BaseContainer()
     menu.InsData(c4d.MENURESOURCE_SUBTITLE, "AYON")
 
+    # Bugfix: Using hardcoded int because Maxon renamed the
+    # `c4d.MENURESOURCE_SEPERATOR` to `c4d.MENURESOURCE_SEPARATOR`
+    # and this saves us the version checks
+    # See: http://developers.maxon.net/forum//post/72528
+    menuresource_separator = 2
+
     # Define menu commands
     add_command(menu, Creator)
     add_command(menu, Loader)
     add_command(menu, Publish)
     add_command(menu, Manage)
     add_command(menu, Library)
-    menu.InsData(c4d.MENURESOURCE_SEPERATOR, True)
+    menu.InsData(menuresource_separator, True)
     add_command(menu, Workfiles)
-    menu.InsData(c4d.MENURESOURCE_SEPERATOR, True)
+    menu.InsData(menuresource_separator, True)
     add_command(menu, ResetFrameRange)
     add_command(menu, ResetSceneResolution)
     add_command(menu, ResetColorspace)
-    menu.InsData(c4d.MENURESOURCE_SEPERATOR, True)
+    menu.InsData(menuresource_separator, True)
     # add_command(menu, BuildWorkFileCommand)
     add_command(menu, ExperimentalTools)
 


### PR DESCRIPTION
## Changelog Description

Fix support for Cinema4D 2024+

## Additional info

Fixes error reported [here](https://discord.com/channels/517362899170230292/1288948103981830315/1296796473572196373):

```python
Traceback (most recent call last):
  File "C:\Users\Remco\AppData\Local\Ynput\AYON\addons\cinema4d_0.1.1\ayon_cinema4d\startup\ayon_cinema4d.pyp", line 240, in PluginMessage
install_menu()
  File "C:\Users\Remco\AppData\Local\Ynput\AYON\addons\cinema4d_0.1.1\ayon_cinema4d\startup\ayon_cinema4d.pyp", line 218, in install_menu
menu.InsData(c4d.MENURESOURCE_SEPERATOR, True)
^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError:module 'c4d' has no attribute 'MENURESOURCE_SEPERATOR'
```

Maxon renamed the constant `c4d.MENURESOURCE_SEPERATOR` to `c4d.MENURESOURCE_SEPARATOR`
See: http://developers.maxon.net/forum//post/72528

## Testing notes:

1. Run Cinema4D 2024 or 2025
