### PR TITLE
Set resolution using the virtual resolution and set pixel aspect ratio from entity

### DIFF
--- a/client/ayon_cinema4d/api/lib.py
+++ b/client/ayon_cinema4d/api/lib.py
@@ -476,9 +476,9 @@ def set_resolution_from_entity(task_entity, doc=None):
         # TODO: Confirm whether we must unlock e.g. aspect ratio lock to allow
         #  changing the render resolution aspect ratio?
         rd.SetParameter(
-            c4d.RDATA_YRES_VIRTUAL, width, c4d.DESCFLAGS_SET_USERINTERACTION)
+            c4d.RDATA_XRES_VIRTUAL, width, c4d.DESCFLAGS_SET_USERINTERACTION)
         rd.SetParameter(
-            c4d.RDATA_XRES_VIRTUAL, height, c4d.DESCFLAGS_SET_USERINTERACTION)
+            c4d.RDATA_YRES_VIRTUAL, height, c4d.DESCFLAGS_SET_USERINTERACTION)
 
         # Set pixel aspect ratio
         rd[c4d.RDATA_PIXELASPECT] = pixel_aspect

--- a/client/ayon_cinema4d/api/lib.py
+++ b/client/ayon_cinema4d/api/lib.py
@@ -467,10 +467,21 @@ def set_resolution_from_entity(task_entity, doc=None):
     attrib = task_entity["attrib"]
     width: int = int(attrib["resolutionWidth"])
     height: int = int(attrib["resolutionHeight"])
+    pixel_aspect: float = attrib["pixelAspect"]
 
     rd = doc.GetFirstRenderData()
     while rd:
-        rd[c4d.RDATA_XRES] = width
-        rd[c4d.RDATA_YRES] = height
+        # Fix #20: Set the virtual resolution with user interaction so Redshift
+        # still triggers some additional checks on the attribute change.
+        # TODO: Confirm whether we must unlock e.g. aspect ratio lock to allow
+        #  changing the render resolution aspect ratio?
+        rd.SetParameter(
+            c4d.RDATA_YRES_VIRTUAL, width, c4d.DESCFLAGS_SET_USERINTERACTION)
+        rd.SetParameter(
+            c4d.RDATA_XRES_VIRTUAL, height, c4d.DESCFLAGS_SET_USERINTERACTION)
+
+        # Set pixel aspect ratio
+        rd[c4d.RDATA_PIXELASPECT] = pixel_aspect
+
         rd = rd.GetNext()
     c4d.EventAdd()


### PR DESCRIPTION
## Changelog Description

Set resolution using the virtual resolution and set pixel aspect ratio from entity

## Additional review information

Fix #20 

## Testing notes:

1. Setting resolution should consider updating the film aspect ratio and pixel aspect ratio