### PR TITLE
Fix Alembic Loader trying to update alembic path on non-alembic generators

### DIFF
--- a/client/ayon_cinema4d/plugins/load/load_alembic.py
+++ b/client/ayon_cinema4d/plugins/load/load_alembic.py
@@ -93,12 +93,8 @@ class AlembicLoader(plugin.Cinema4DLoader):
             objects.update(children)
 
         for obj in objects:
-            # Only update those with alembic path set
-            # Fix #27: This may return an integer like `2` on some nodes, e.g.
-            # Subdivision Surface, for whatever reason that do not have an
-            # alembic path to set. So we skip if the result is not a string.
-            alembic_path_value = obj[c4d.ALEMBIC_PATH]
-            if alembic_path_value and isinstance(alembic_path_value, str):
+            # Update Alembic Generators
+            if obj.IsInstanceOf(c4d.Oalembicgenerator):
                 obj[c4d.ALEMBIC_PATH] = filepath
                 continue
 

--- a/client/ayon_cinema4d/plugins/load/load_alembic.py
+++ b/client/ayon_cinema4d/plugins/load/load_alembic.py
@@ -94,7 +94,11 @@ class AlembicLoader(plugin.Cinema4DLoader):
 
         for obj in objects:
             # Only update those with alembic path set
-            if obj[c4d.ALEMBIC_PATH]:
+            # Fix #27: This may return an integer like `2` on some nodes, e.g.
+            # Subdivision Surface, for whatever reason that do not have an
+            # alembic path to set. So we skip if the result is not a string.
+            alembic_path_value = obj[c4d.ALEMBIC_PATH]
+            if alembic_path_value and isinstance(alembic_path_value, str):
                 obj[c4d.ALEMBIC_PATH] = filepath
                 continue
 


### PR DESCRIPTION
## Changelog Description

Fix alembic updating that have new objects in its hierarchy that are not part of the alembic.

## Additional review information

Fix #27 

Do note that the logic here shows another issue at hand. If you were to parent on alembic to another - the update logic will try to update the child alembic as part of the parent loaded one because it recurses its full hierarchy. We should instead find a way to accurately track which objects _really_ belong to the container if we can.

# Testing notes:

1. Load alembic
2. Parent "Subdivision Surface" underneath on of the objects.
3. Updating the alembic should still work.