### PR TITLE
 Add default_variant for workfile creator

### DIFF
--- a/client/ayon_cinema4d/plugins/create/create_workfile.py
+++ b/client/ayon_cinema4d/plugins/create/create_workfile.py
@@ -16,6 +16,7 @@ class CreateWorkfile(AutoCreator):
     label = "Workfile"
     product_type = "workfile"
     icon = "fa5.file"
+    default_variant = "Main"
 
     node_name = "AYON_workfile"
 


### PR DESCRIPTION
## Changelog Description
This PR is to resolve the bug of `error: CreateWorkfile' object has no attribute 'default_variant'` when publishing workfile by changing the current context.

## Additional review information
n/a

## Testing notes:
1. Publish Workfile
2. Changing the context
<img width="598" height="168" alt="image" src="https://github.com/user-attachments/assets/43093fbd-d636-46b6-bfa2-fc42e4c70cdb" />

3. Save and Refresh, the error should be disappeared
4. Publish Workfile also succeeded.

