### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_cinema4d/plugins/create/create_workfile.py
+++ b/client/ayon_cinema4d/plugins/create/create_workfile.py
@@ -47,7 +47,7 @@ class CreateWorkfile(AutoCreator):
                 project_name=project_name,
                 folder_entity=folder_entity,
                 task_entity=task_entity,
-                variant=task_name,
+                variant=self.default_variant,
                 host_name=host_name,
             )
             data = {


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
