### PR TITLE
Remove redundant `Host.__init__`

### DIFF
--- a/client/ayon_cinema4d/api/pipeline.py
+++ b/client/ayon_cinema4d/api/pipeline.py
@@ -44,9 +44,6 @@ AYON_CONTEXT_CREATOR_IDENTIFIER = "io.ayon.create.context"
 class Cinema4DHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "cinema4d"
 
-    def __init__(self):
-        super(Cinema4DHost, self).__init__()
-
     def install(self):
         # process path mapping
         # dirmap_processor = Cinema4DDirmap("cinema4d", project_settings)


### PR DESCRIPTION
## Changelog Description

Remove redundant `Host.__init__`

## Additional review information

Just cleanup.

## Testing notes:

1. Integration still works