### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_cinema4d/plugins/create/create_camera.py
+++ b/client/ayon_cinema4d/plugins/create/create_camera.py
@@ -12,6 +12,7 @@ class CreateCamera(plugin.Cinema4DCreator):
     label = "Camera"
     description = __doc__
     product_type = "camera"
+    product_base_type = "camera"
     icon = "video-camera"
 
     def get_instance_attr_defs(self):

--- a/client/ayon_cinema4d/plugins/create/create_pointcache.py
+++ b/client/ayon_cinema4d/plugins/create/create_pointcache.py
@@ -11,6 +11,7 @@ class CreatePointcache(plugin.Cinema4DCreator):
     label = "Pointcache"
     description = __doc__
     product_type = "pointcache"
+    product_base_type = "pointcache"
     icon = "cubes"
 
     def get_instance_attr_defs(self):

--- a/client/ayon_cinema4d/plugins/create/create_redshift_proxy.py
+++ b/client/ayon_cinema4d/plugins/create/create_redshift_proxy.py
@@ -10,6 +10,7 @@ class CreateRedshiftProxy(plugin.Cinema4DCreator):
     identifier = "io.ayon.creators.cinema4d.redshiftproxy"
     label = "Redshift Proxy"
     product_type = "redshiftproxy"
+    product_base_type = "redshiftproxy"
     description = __doc__
     icon = "cubes"
 

--- a/client/ayon_cinema4d/plugins/create/create_render.py
+++ b/client/ayon_cinema4d/plugins/create/create_render.py
@@ -27,6 +27,7 @@ class RenderlayerCreator(plugin.Cinema4DCreator):
     description = "Create a render product per Cinema4D Take."
     detailed_description = inspect.cleandoc(__doc__)
     product_type = "render"
+    product_base_type = "render"
     icon = "eye"
 
     _required_keys = ("creator_identifier", "productName")

--- a/client/ayon_cinema4d/plugins/create/create_review.py
+++ b/client/ayon_cinema4d/plugins/create/create_review.py
@@ -11,6 +11,7 @@ class CreateReview(plugin.Cinema4DCreator):
     label = "Review"
     description = __doc__
     product_type = "review"
+    product_base_type = "review"
     icon = "video-camera"
 
     def get_instance_attr_defs(self):

--- a/client/ayon_cinema4d/plugins/create/create_workfile.py
+++ b/client/ayon_cinema4d/plugins/create/create_workfile.py
@@ -14,6 +14,7 @@ class CreateWorkfile(AutoCreator):
     identifier = "io.ayon.creators.cinema4d.workfile"
     label = "Workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
     icon = "fa5.file"
     default_variant = "Main"
 


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.